### PR TITLE
Shorthand for registering partials at initialization didn't work for me.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ $('#content').render('template', {
 });
 ```
 
-As a shorthand you can register all the partials at inizialization time using the `partials` configuration setting:
+As a shorthand you can register all the partials at initialization time using the `partials` configuration setting:
 
 ```javascript
 $.handlebars({

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -38,6 +38,9 @@
 	$.handlebars = function () {
 		if (typeof arguments[0] !== 'string') {
 			var options = arguments[0];
+			settings = $.extend(defaultSettings, arguments[0]);
+			settings.templatePath = settings.templatePath.replace(/\\\/$/, '');
+			settings.partialPath = settings.partialPath.replace(/\\\/$/, '');
 			if (options.hasOwnProperty('partials')) {
 				var names;
 				if (typeof options.partials !== 'string') {
@@ -49,9 +52,6 @@
 					registerPartial(names[i], names[i]);
 				}
 			}
-			settings = $.extend(defaultSettings, arguments[0]);
-			settings.templatePath = settings.templatePath.replace(/\\\/$/, '');
-			settings.partialPath = settings.partialPath.replace(/\\\/$/, '');
 		} else {
 			switch (arguments[0]) {
 			case 'partial':


### PR DESCRIPTION
With settings like this

``` javascript
$.handlebars({
    templatePath: 'js/templates',
    templateExtension: 'hbs',
    partialPath: 'js/templates/partials',
    partialExtension: 'partial',
    partials: ['element'] // need to register partials
});
```

`resolvePartialPath` would always return empty string, since `settings.partialPath` was not set. Moving settings before registering partials (as you can see in my commit) worked for me. I tried also with separate registering and it worked. Hope I didn't break something else.
- readme typo
