### PR TITLE
Callback after rendering is done 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Getting Started
 Each jQuery object has a `render` method that:
 - retrieves the specified template (either from cache or by fetching through AJAX and compiling with Handlebars),
 - renders it through Handlebars using the specified context object,
-- passes the output string to the jQuery object's `html` method.
+- passes the output string to the jQuery object's `html` method,
+- optionally allows you to specify a callback function that is executed after rendering the template.
 
 Example:
 
@@ -47,6 +48,16 @@ $('#some-element').render('content', {
 ```
 
 The second argument to the `render` method is of course the context to use in Handlebars to render the template.
+
+The third argument to the `render`method is a optional callback to allow for additional processing after the rendering is done.
+
+```javascript
+$.handlebars.render('content', {
+	// ...
+}, function(output) {
+	alert("Rendering done!");
+});
+```
 
 Helpers and partials
 --------------------

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -70,7 +70,7 @@
 		}
 	};
 
-	$.fn.render = function (templateName, data) {
+	$.fn.render = function (templateName, data, callback) {
 		var url = resolveTemplatePath(templateName);
 		if (cache.hasOwnProperty(url)) {
 			this.html(cache[url](data)).trigger('render.handlebars', [templateName, data]);
@@ -79,7 +79,7 @@
 			$.get(url, function (template) {
 				cache[url] = Handlebars.compile(template);
 				$this.html(cache[url](data)).trigger('render.handlebars', [templateName, data]);
-			}, 'text');
+			}, 'text').then(callback);
 		}
 		return this;
 	};


### PR DESCRIPTION
While playing with this plugin I had the problem, that after rendering a template I wanted to bind some event-handlers  to the newly rendered markup. As I found no obvious way to wait for the rendering/$.get request to finish I added a callback method. 
Maybe this is something useful for others?

Regards
Chris
