### PR TITLE
Add Inline Template and Precompiling Templates Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /bin/
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,7 +50,7 @@ module.exports = function (grunt) {
 			},
 			dist: {
 				src: [
-					'src/handlebars-1.0.0.js',
+					//'src/handlebars-1.0.0.js',
 					'src/plugin.js'
 				],
 				dest: 'bin/jquery-handlebars-<%= pkg.version %>.min.js'
@@ -60,7 +60,7 @@ module.exports = function (grunt) {
 		concat: {
 			dist: {
 				src: [
-					'src/handlebars-1.0.0.js',
+					//'src/handlebars-1.0.0.js',
 					'src/plugin.js'
 				],
 				dest: 'bin/jquery-handlebars-<%= pkg.version %>.js'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
 				curly: true,
 				forin: true,
 				immed: true,
-				indent: 4,
+				indent: 2,
 				latedef: true,
 				newcap: true,
 				noarg: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jquery-handlebars",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"description": "A templating engine for jQuery based on Handlebars.js",
 	"keywords": [
 		"template",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jquery-handlebars",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"description": "A templating engine for jQuery based on Handlebars.js",
 	"keywords": [
 		"template",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jquery-handlebars",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"description": "A templating engine for jQuery based on Handlebars.js",
 	"keywords": [
 		"template",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -51,18 +51,18 @@
 		return 'cache_' + templateName;
 	}
 
-    function isPreCompiled(templateName) {
-        return Handlebars.hasOwnProperty('templates') &&
-            Handlebars.templates.hasOwnProperty(templateName);
-    }
+	function isPreCompiled(templateName) {
+		return Handlebars.hasOwnProperty('templates') &&
+			Handlebars.templates.hasOwnProperty(templateName);
+	}
 
-    function isCached(templateName) {
-        return cache.hasOwnProperty(getCacheKey(templateName));
-    }
+	function isCached(templateName) {
+		return cache.hasOwnProperty(getCacheKey(templateName));
+	}
 
 	function render($this, templateName, data) {
 		var template = isPreCompiled(templateName) ?
-            Handlebars.templates[templateName] : cache[getCacheKey(templateName)];
+			Handlebars.templates[templateName] : cache[getCacheKey(templateName)];
 		var content = template(data);
 		$this.html(content).trigger('render.handlebars', [templateName, data]);
 	}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -51,9 +51,18 @@
 		return 'cache_' + templateName;
 	}
 
+    function isPreCompiled(templateName) {
+        return Handlebars.hasOwnProperty('templates') &&
+            Handlebars.templates.hasOwnProperty(templateName);
+    }
+
+    function isCached(templateName) {
+        return cache.hasOwnProperty(getCacheKey(templateName));
+    }
+
 	function render($this, templateName, data) {
-		var cacheKey = getCacheKey(templateName);
-		var template = cache[cacheKey];
+		var template = isPreCompiled(templateName) ?
+            Handlebars.templates[templateName] : cache[getCacheKey(templateName)];
 		var content = template(data);
 		$this.html(content).trigger('render.handlebars', [templateName, data]);
 	}
@@ -99,8 +108,7 @@
 	};
 
 	$.fn.render = function (templateName, data) {
-		var cacheKey = getCacheKey(templateName);
-		if (cache.hasOwnProperty(cacheKey)) {
+		if (isPreCompiled(templateName) || isCached(templateName)) {
 			render(this, templateName, data);
 			return this;
 		}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -60,11 +60,14 @@
     return cache.hasOwnProperty(getCacheKey(templateName));
   }
 
-  function render($this, templateName, data) {
+  function render($this, templateName, data, domMethod) {
+    if (!domMethod) {
+      domMethod = 'html';
+    }
     var template = isPreCompiled(templateName) ?
       Handlebars.templates[templateName] : cache[getCacheKey(templateName)];
     var content = template(data);
-    $this.html(content).trigger('render.handlebars', [templateName, data]);
+    $this[domMethod].call($this, content).trigger('render.handlebars', [templateName, data]);
   }
 
   function cacheTemplate(templateName, templateContent) {
@@ -91,25 +94,25 @@
       }
     } else {
       switch (arguments[0]) {
-        case 'partial':
-          if (arguments.length < 3) {
-            registerPartial(arguments[1], arguments[1]);
-          } else {
-            registerPartial(arguments[1], arguments[2]);
-          }
-          break;
-        case 'helper':
-          Handlebars.registerHelper(arguments[1], arguments[2]);
-          break;
-        default:
-          throw 'invalid action specified to jQuery.handlebars: ' + arguments[0];
+      case 'partial':
+        if (arguments.length < 3) {
+          registerPartial(arguments[1], arguments[1]);
+        } else {
+          registerPartial(arguments[1], arguments[2]);
+        }
+        break;
+      case 'helper':
+        Handlebars.registerHelper(arguments[1], arguments[2]);
+        break;
+      default:
+        throw 'invalid action specified to jQuery.handlebars: ' + arguments[0];
       }
     }
   };
 
-  $.fn.render = function (templateName, data) {
+  $.fn.render = function (templateName, data, domMethod) {
     if (isPreCompiled(templateName) || isCached(templateName)) {
-      render(this, templateName, data);
+      render(this, templateName, data, domMethod);
       return this;
     }
     var promise = null;
@@ -127,8 +130,8 @@
     var $this = this;
     promise.done(function (template) {
       cacheTemplate(templateName, template);
-      render($this, templateName, data);
-    }).fail(function( jqXHR, textStatus, errorThrown) {
+      render($this, templateName, data, domMethod);
+    }).fail(function (jqXHR, textStatus, errorThrown) {
       throw new Error('template: ' + templateName + ' ' + errorThrown);
     });
     return this;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,134 +1,144 @@
 (function ($) {
-	'use strict';
+  'use strict';
 
-	var cache = {};
+  var cache = {};
 
-	var defaultSettings = {
-		templatePath: '',
-		templateExtension: 'handlebars',
-		partialPath: '',
-		partialExtension: 'partial'
-	};
+  var defaultSettings = {
+    templatePath: '',
+    templateExtension: 'handlebars',
+    partialPath: '',
+    partialExtension: 'partial'
+  };
 
-	var settings = $.extend({}, defaultSettings);
+  var settings = $.extend({}, defaultSettings);
 
-	function resolvePath(basePath, name, extension) {
-		basePath = basePath.replace(/[(^\s)(\s$)]/g, '');
-		if (basePath.length) {
-			return basePath + '/' + name + '.' + extension;
-		} else {
-			return name + '.' + extension;
-		}
-	}
+  function resolvePath(basePath, name, extension) {
+    basePath = basePath.replace(/[(^\s)(\s$)]/g, '');
+    if (basePath.length) {
+      return basePath + '/' + name + '.' + extension;
+    } else {
+      return name + '.' + extension;
+    }
+  }
 
-	function resolveTemplatePath(name) {
-		return resolvePath(settings.templatePath, name, settings.templateExtension);
-	}
+  function resolveTemplatePath(name) {
+    return resolvePath(settings.templatePath, name, settings.templateExtension);
+  }
 
-	function resolvePartialPath(name) {
-		return resolvePath(settings.partialPath, name, settings.partialExtension);
-	}
+  function resolvePartialPath(name) {
+    return resolvePath(settings.partialPath, name, settings.partialExtension);
+  }
 
-	function registerPartial(path, name) {
-		var promise = null;
-		if (path.charAt(0) === '#') {
-			var defer = $.Deferred();
-			promise = defer.promise();
-			defer.resolve($(path).html());
-		}
-		else {
-			promise = $.ajax({
-				url: resolvePartialPath(path),
-				dataType: 'text'
-			});
-		}
-		promise.done(function (partial) {
-			Handlebars.registerPartial(name, partial);
-		});
-	}
+  function registerPartial(path, name) {
+    var promise = null;
+    if (path.charAt(0) === '#') {
+      var defer = $.Deferred();
+      promise = defer.promise();
+      defer.resolve($(path).html());
+    }
+    else {
+      promise = $.ajax({
+        url: resolvePartialPath(path),
+        dataType: 'text'
+      });
+    }
+    promise.done(function (partial) {
+      Handlebars.registerPartial(name, partial);
+    });
+  }
 
-	function getCacheKey(templateName) {
-		return 'cache_' + templateName;
-	}
+  function getCacheKey(templateName) {
+    return 'cache_' + templateName;
+  }
 
-	function isPreCompiled(templateName) {
-		return Handlebars.hasOwnProperty('templates') &&
-			Handlebars.templates.hasOwnProperty(templateName);
-	}
+  function isPreCompiled(templateName) {
+    return Handlebars.hasOwnProperty('templates') &&
+      Handlebars.templates.hasOwnProperty(templateName);
+  }
 
-	function isCached(templateName) {
-		return cache.hasOwnProperty(getCacheKey(templateName));
-	}
+  function isCached(templateName) {
+    return cache.hasOwnProperty(getCacheKey(templateName));
+  }
 
-	function render($this, templateName, data) {
-		var template = isPreCompiled(templateName) ?
-			Handlebars.templates[templateName] : cache[getCacheKey(templateName)];
-		var content = template(data);
-		$this.html(content).trigger('render.handlebars', [templateName, data]);
-	}
+  function render($this, templateName, data) {
+    var template = isPreCompiled(templateName) ?
+      Handlebars.templates[templateName] : cache[getCacheKey(templateName)];
+    var content = template(data);
+    $this.html(content).trigger('render.handlebars', [templateName, data]);
+  }
 
-	function cacheTemplate(templateName, templateContent) {
-		var cacheKey = getCacheKey(templateName);
-		cache[cacheKey] = Handlebars.compile(templateContent);
-	}
+  function cacheTemplate(templateName, templateContent) {
+    var cacheKey = getCacheKey(templateName);
+    cache[cacheKey] = Handlebars.compile(templateContent);
+  }
 
-	$.handlebars = function () {
-		if (typeof arguments[0] !== 'string') {
-			var options = arguments[0];
-			settings = $.extend(defaultSettings, options);
-			settings.templatePath = settings.templatePath.replace(/\\\/$/, '');
-			settings.partialPath = settings.partialPath.replace(/\\\/$/, '');
-			if (options.hasOwnProperty('partials')) {
-				var names;
-				if (typeof options.partials !== 'string') {
-					names = options.partials;
-				} else {
-					names = options.partials.split(/\s+/g);
-				}
-				for (var i = 0; i < names.length; i++) {
-					registerPartial(names[i], names[i]);
-				}
-			}
-		} else {
-			switch (arguments[0]) {
-			case 'partial':
-				if (arguments.length < 3) {
-					registerPartial(arguments[1], arguments[1]);
-				} else {
-					registerPartial(arguments[1], arguments[2]);
-				}
-				break;
-			case 'helper':
-				Handlebars.registerHelper(arguments[1], arguments[2]);
-				break;
-			default:
-				throw 'invalid action specified to jQuery.handlebars: ' + arguments[0];
-			}
-		}
-	};
+  $.handlebars = function () {
+    if (typeof arguments[0] !== 'string') {
+      var options = arguments[0];
+      settings = $.extend(defaultSettings, options);
+      settings.templatePath = settings.templatePath.replace(/\\\/$/, '');
+      settings.partialPath = settings.partialPath.replace(/\\\/$/, '');
+      if (options.hasOwnProperty('partials')) {
+        var names;
+        if (typeof options.partials !== 'string') {
+          names = options.partials;
+        } else {
+          names = options.partials.split(/\s+/g);
+        }
+        for (var i = 0; i < names.length; i++) {
+          registerPartial(names[i], names[i]);
+        }
+      }
+    } else {
+      switch (arguments[0]) {
+        case 'partial':
+          if (arguments.length < 3) {
+            registerPartial(arguments[1], arguments[1]);
+          } else {
+            registerPartial(arguments[1], arguments[2]);
+          }
+          break;
+        case 'helper':
+          Handlebars.registerHelper(arguments[1], arguments[2]);
+          break;
+        default:
+          throw 'invalid action specified to jQuery.handlebars: ' + arguments[0];
+      }
+    }
+  };
 
-	$.fn.render = function (templateName, data) {
-		if (isPreCompiled(templateName) || isCached(templateName)) {
-			render(this, templateName, data);
-			return this;
-		}
-		var promise = null;
-		if (templateName.charAt(0) === '#') {
-			var defer = $.Deferred();
-			promise = defer.promise();
-			defer.resolve($(templateName).html());
-		}
-		else {
-			promise = $.ajax({
-				url: resolveTemplatePath(templateName),
-				dataType: 'text'
-			});
-		}
-		var $this = this;
-		promise.done(function (template) {
-			cacheTemplate(templateName, template);
-			render($this, templateName, data);
-		});
-		return this;
-	};
+  $.fn.render = function (templateName, data) {
+    if (isPreCompiled(templateName) || isCached(templateName)) {
+      render(this, templateName, data);
+      return this;
+    }
+    var promise = null;
+    if (templateName.charAt(0) === '#') {
+      var defer = $.Deferred();
+      promise = defer.promise();
+      defer.resolve($(templateName).html());
+    }
+    else {
+      promise = $.ajax({
+        url: resolveTemplatePath(templateName),
+        dataType: 'text'
+      });
+    }
+    var $this = this;
+    promise.done(function (template) {
+      cacheTemplate(templateName, template);
+      render($this, templateName, data);
+    }).fail(function( jqXHR, textStatus, errorThrown) {
+      throw new Error('template: ' + templateName + ' ' + errorThrown);
+    });
+    return this;
+  };
+
+  $.fn.renderAsync = function (templateName, data) {
+    var defer = $.Deferred();
+    this.one('render.handlebars', function (templateName, data) {
+      defer.resolve(templateName, data);
+    }).render(templateName, data);
+    return defer.promise();
+  };
 }(jQuery));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -137,11 +137,11 @@
     return this;
   };
 
-  $.fn.renderAsync = function (templateName, data) {
+  $.fn.renderAsync = function (templateName, data, domMethod) {
     var defer = $.Deferred();
     this.one('render.handlebars', function (templateName, data) {
       defer.resolve(templateName, data);
-    }).render(templateName, data);
+    }).render(templateName, data, domMethod);
     return defer.promise();
   };
 }(jQuery));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,6 +35,22 @@
 		}, 'text');
 	}
 
+    function getCacheKey(templateName) {
+        return 'cache_' + templateName;
+    }
+
+    function render($this, templateName, data) {
+        var cacheKey = getCacheKey(templateName);
+        var template = cache[cacheKey];
+        var content = template(data);
+        $this.html(content).trigger('render.handlebars', [templateName, data]);
+    }
+
+    function cacheTemplate(templateName, templateContent) {
+        var cacheKey = getCacheKey(templateName);
+        cache[cacheKey] = Handlebars.compile(templateContent);
+    }
+
 	$.handlebars = function () {
 		if (typeof arguments[0] !== 'string') {
 			var options = arguments[0];
@@ -71,16 +87,28 @@
 	};
 
 	$.fn.render = function (templateName, data) {
-		var url = resolveTemplatePath(templateName);
-		if (cache.hasOwnProperty(url)) {
-			this.html(cache[url](data)).trigger('render.handlebars', [templateName, data]);
-		} else {
-			var $this = this;
-			$.get(url, function (template) {
-				cache[url] = Handlebars.compile(template);
-				$this.html(cache[url](data)).trigger('render.handlebars', [templateName, data]);
-			}, 'text');
-		}
+        var cacheKey = getCacheKey(templateName);
+        if (cache.hasOwnProperty(cacheKey)) {
+            render(this, templateName, data);
+            return this;
+        }
+        var promise = null;
+        if (templateName.charAt(0) === '#') {
+            var defer = $.Deferred();
+            promise = defer.promise();
+            defer.resolve($(templateName).html());
+        }
+        else {
+            promise = $.ajax({
+                url: resolveTemplatePath(templateName),
+                dataType: 'text'
+            });
+        }
+        var $this = this;
+        promise.done(function (template) {
+            cacheTemplate(templateName, template);
+            render($this, templateName, data);
+        });
 		return this;
 	};
 }(jQuery));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -30,38 +30,38 @@
 	}
 
 	function registerPartial(path, name) {
-        var promise = null;
-        if (path.charAt(0) === '#') {
-            var defer = $.Deferred();
-            promise = defer.promise();
-            defer.resolve($(path).html());
-        }
-        else {
-            promise = $.ajax({
-                url: resolvePartialPath(path),
-                dataType: 'text'
-            });
-        }
-        promise.done(function (partial) {
-            Handlebars.registerPartial(name, partial);
-        });
+		var promise = null;
+		if (path.charAt(0) === '#') {
+			var defer = $.Deferred();
+			promise = defer.promise();
+			defer.resolve($(path).html());
+		}
+		else {
+			promise = $.ajax({
+				url: resolvePartialPath(path),
+				dataType: 'text'
+			});
+		}
+		promise.done(function (partial) {
+			Handlebars.registerPartial(name, partial);
+		});
 	}
 
-    function getCacheKey(templateName) {
-        return 'cache_' + templateName;
-    }
+	function getCacheKey(templateName) {
+		return 'cache_' + templateName;
+	}
 
-    function render($this, templateName, data) {
-        var cacheKey = getCacheKey(templateName);
-        var template = cache[cacheKey];
-        var content = template(data);
-        $this.html(content).trigger('render.handlebars', [templateName, data]);
-    }
+	function render($this, templateName, data) {
+		var cacheKey = getCacheKey(templateName);
+		var template = cache[cacheKey];
+		var content = template(data);
+		$this.html(content).trigger('render.handlebars', [templateName, data]);
+	}
 
-    function cacheTemplate(templateName, templateContent) {
-        var cacheKey = getCacheKey(templateName);
-        cache[cacheKey] = Handlebars.compile(templateContent);
-    }
+	function cacheTemplate(templateName, templateContent) {
+		var cacheKey = getCacheKey(templateName);
+		cache[cacheKey] = Handlebars.compile(templateContent);
+	}
 
 	$.handlebars = function () {
 		if (typeof arguments[0] !== 'string') {
@@ -99,28 +99,28 @@
 	};
 
 	$.fn.render = function (templateName, data) {
-        var cacheKey = getCacheKey(templateName);
-        if (cache.hasOwnProperty(cacheKey)) {
-            render(this, templateName, data);
-            return this;
-        }
-        var promise = null;
-        if (templateName.charAt(0) === '#') {
-            var defer = $.Deferred();
-            promise = defer.promise();
-            defer.resolve($(templateName).html());
-        }
-        else {
-            promise = $.ajax({
-                url: resolveTemplatePath(templateName),
-                dataType: 'text'
-            });
-        }
-        var $this = this;
-        promise.done(function (template) {
-            cacheTemplate(templateName, template);
-            render($this, templateName, data);
-        });
+		var cacheKey = getCacheKey(templateName);
+		if (cache.hasOwnProperty(cacheKey)) {
+			render(this, templateName, data);
+			return this;
+		}
+		var promise = null;
+		if (templateName.charAt(0) === '#') {
+			var defer = $.Deferred();
+			promise = defer.promise();
+			defer.resolve($(templateName).html());
+		}
+		else {
+			promise = $.ajax({
+				url: resolveTemplatePath(templateName),
+				dataType: 'text'
+			});
+		}
+		var $this = this;
+		promise.done(function (template) {
+			cacheTemplate(templateName, template);
+			render($this, templateName, data);
+		});
 		return this;
 	};
 }(jQuery));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -30,9 +30,21 @@
 	}
 
 	function registerPartial(path, name) {
-		$.get(resolvePartialPath(path), function (partial) {
-			Handlebars.registerPartial(name, partial);
-		}, 'text');
+        var promise = null;
+        if (path.charAt(0) === '#') {
+            var defer = $.Deferred();
+            promise = defer.promise();
+            defer.resolve($(path).html());
+        }
+        else {
+            promise = $.ajax({
+                url: resolvePartialPath(path),
+                dataType: 'text'
+            });
+        }
+        promise.done(function (partial) {
+            Handlebars.registerPartial(name, partial);
+        });
 	}
 
     function getCacheKey(templateName) {


### PR DESCRIPTION
Add inline template support. To use it like this:

``` html
<script id="test" type="text/html">
    <div>{{ title }}-{{ name }}</div>
</script>
```

``` javascript
$("#version").render("#test", {title: 'version', name: '0.0.1'});
```
