### PR TITLE
Added sync option to always render templates synchronously

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,7 +7,8 @@
 		templatePath: '',
 		templateExtension: 'handlebars',
 		partialPath: '',
-		partialExtension: 'partial'
+		partialExtension: 'partial',
+		sync: false,
 	};
 
 	var settings = $.extend({}, defaultSettings);
@@ -64,6 +65,20 @@
 			case 'helper':
 				Handlebars.registerHelper(arguments[1], arguments[2]);
 				break;
+			case 'add':
+				var tplname = arguments[1];
+				var tpldata = arguments[2];
+				console.log('h.add', tplname);
+				cache[ tplname ] = Handlebars.compile(tpldata);
+				break;
+			case 'has':
+				var tplname = arguments[1];
+				var res = !! cache.hasOwnProperty( tplname );
+				console.log('h.has', tplname, res);
+				return res;
+				break;
+			case 'cache':
+				return cache;
 			default:
 				throw 'invalid action specified to jQuery.handlebars: ' + arguments[0];
 			}
@@ -71,16 +86,25 @@
 	};
 
 	$.fn.render = function (templateName, data) {
-		var url = resolveTemplatePath(templateName);
-		if (cache.hasOwnProperty(url)) {
-			this.html(cache[url](data)).trigger('render.handlebars', [templateName, data]);
+		if (cache.hasOwnProperty( templateName )) {
+			this.html(cache[templateName](data)).trigger('render.handlebars', [templateName, data]);
+		} else if (settings.sync) {
+			console.warn({
+				msg: 'template not in cache',
+				tpl: templateName,
+				cache: cache,
+				settings: settings,
+			});
+			throw "jquery.handlerbars.sync: Template not in cache and sync = true: " + templateName;
 		} else {
+			var url = resolveTemplatePath(templateName);
 			var $this = this;
 			$.get(url, function (template) {
-				cache[url] = Handlebars.compile(template);
-				$this.html(cache[url](data)).trigger('render.handlebars', [templateName, data]);
+				cache[templateName] = Handlebars.compile(template);
+				$this.html(cache[templateName](data)).trigger('render.handlebars', [templateName, data]);
 			}, 'text');
 		}
+
 		return this;
 	};
 }(jQuery));


### PR DESCRIPTION
Added sync option - when true, $.fn.render calls that can't find the template without ajax throw an exception
- option sync - false by default
  when true, no ajax calls are performed
- $.handlebars( 'add', templateName, templateString )
  to add a template to cache
- $.handlebars( 'has', templateName ) -> bool
  returns whether the template is already cached
  
  because if ! has tpl { add tpl; render } is nicer than catching
- $.handlebars( 'cache' ) -> the cache object

Templates are no longer cached by URL, only by template name.
(Because locally added templates have no url and inventing a fake one would complicate searching if both ways are used.)

The rationale is to be reasonably compatible with jquery.mustache.js, because while converting `$.fn.mustache( tpl, data, { method: html })` to `$.fn.render( tpl, data )` is easy, lots of code written for mustache expects the template to be rendered synchronously, and without `sync: true`, `$('#foo').render('tpl', {}); $('#foo .something').whatever();` doesn't really work (except when it does).
