### PR TITLE
Added render callback argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ $('#some-element').render('content', {
 
 The second argument to the `render` method is of course the context to use in Handlebars to render the template.
 
+```javascript
+// will fetch <template.handlebars> and render to the DOM element whose id is "content"
+$('#content').render('template', {
+	field1: 'Hello',
+	field2: 'world!'
+}, function () {
+	$('#content2').render('template2', {
+		field1: 'Another template rendered'
+	});
+});
+```
+
+You can also use the third parameter to pass a callback function to be executed after successful application of the
+handlebars template. This helps. chaining multiple template loads.
+
 Helpers and partials
 --------------------
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -70,15 +70,22 @@
 		}
 	};
 
-	$.fn.render = function (templateName, data) {
-		var url = resolveTemplatePath(templateName);
+	$.fn.render = function (templateName, data, callback) {
+		var url = resolveTemplatePath(templateName),
+		    $this = this,
+
+			applyTemplate = function () { // applies html and triggers event
+				var args = [templateName, data];
+				$this.html(cache[url](data)).trigger('render.handlebars', args);
+				$.isFunction(callback) && callback.apply($this, args);
+			};
+
 		if (cache.hasOwnProperty(url)) {
-			this.html(cache[url](data)).trigger('render.handlebars', [templateName, data]);
+			applyTemplate();
 		} else {
-			var $this = this;
 			$.get(url, function (template) {
 				cache[url] = Handlebars.compile(template);
-				$this.html(cache[url](data)).trigger('render.handlebars', [templateName, data]);
+				applyTemplate();
 			}, 'text');
 		}
 		return this;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -76,8 +76,15 @@
 
 			applyTemplate = function () { // applies html and triggers event
 				var args = [templateName, data];
-				$this.html(cache[url](data)).trigger('render.handlebars', args);
-				$.isFunction(callback) && callback.apply($this, args);
+				
+				if ($.isFunction(callback)) {
+					$.when($this.html(cache[url](data)).trigger('render.handlebars', args)).done(function () {
+						callback.apply($this, args);
+					});
+				}
+				else {
+					$this.html(cache[url](data)).trigger('render.handlebars', args);
+				}
 			};
 
 		if (cache.hasOwnProperty(url)) {


### PR DESCRIPTION
This PR modifies the `$.fn.render` function to add a third `callback` argument. When a function is passed as the third argument, the function is executed in the rendered element's context upon successful application of the template. This is useful in chaining template loads.

The `$.when( /* ... */ ).done()` can also be used to arrive to the desired effect, but this is more intuitive for beginners and for rapid prototyping with lesser codes.

Lint checked and README updated.
